### PR TITLE
docs: add WordPress URL migration SQL commands to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,25 @@ gh workflow run main.yml --ref main
 gh run list --workflow=main.yml
 ```
 
+# Migration URL WordPress
+
+Para migrar URLs do WordPress (de produção para staging/local), execute os seguintes comandos SQL no banco de dados:
+
+```sql
+-- Substitua 'https://algumsiteparamigrarlinks.com.br' pela URL de origem
+-- Substitua 'http://localhost:3001' pela URL de destino
+
+UPDATE wp_posts SET guid = REPLACE(guid,'https://algumsiteparamigrarlinks.com.br','http://localhost:3001') WHERE guid LIKE '%https://algumsiteparamigrarlinks.com.br%';
+
+UPDATE wp_posts SET post_content = REPLACE(post_content,'https://algumsiteparamigrarlinks.com.br','http://localhost:3001') WHERE post_content LIKE '%https://algumsiteparamigrarlinks.com.br%';
+
+UPDATE wp_options SET option_value = REPLACE(option_value,'https://algumsiteparamigrarlinks.com.br','http://localhost:3001') WHERE option_value LIKE '%https://algumsiteparamigrarlinks.com.br%';
+
+UPDATE wp_users SET user_url = REPLACE(user_url,'https://algumsiteparamigrarlinks.com.br','http://localhost:3001') WHERE user_url LIKE '%https://algumsiteparamigrarlinks.com.br%';
+```
+
+> **Nota:** O prefixo das tabelas pode variar (wp_ é o padrão). Ajuste conforme o prefixo do seu projeto.
+
 # Duplicator
 
 ### To Install Using Duplicator


### PR DESCRIPTION
## Summary
- Added a new "Migration URL WordPress" section to README with SQL commands for migrating WordPress URLs between environments
- Includes commands to update `wp_posts`, `wp_options`, and `wp_users` tables
- Added note about table prefix variation

## Test plan
- [x] Verify the README renders correctly
- [x] Check SQL syntax is correct